### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,4 +1,6 @@
 name: Renovate
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0/15 * * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/wim-de-groot/4546B/security/code-scanning/1](https://github.com/wim-de-groot/4546B/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the Renovate workflow to function. Based on the workflow's purpose (managing dependencies), it likely only needs `contents: read` to access repository files. If additional permissions are required (e.g., `contents: write` for creating pull requests), they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
